### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/checkstyle-ci.yml
+++ b/.github/workflows/checkstyle-ci.yml
@@ -12,15 +12,18 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]     
+        java-version: [ 8.0.192, 8 ]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 8
+    - name: Set up JDK ${{ matrix.java-version }} ${{ matrix.os }}
       uses: actions/setup-java@v2
       with:
-        java-version: '8'
-        distribution: 'adopt'
+        java-version: ${{ matrix.java-version }}
+        distribution: 'zulu'
         cache: maven
     - name: Checkstyle with Maven
       run: mvn checkstyle:check


### PR DESCRIPTION
Using TCK Tested JDK builds of OpenJDK the latest updated (TCK Tested) builds for all versions of OpenJDK. 

Also added is a fixed (major) release version(s) such as `JDK 8.0.192`. This is often a good practice whenever a build/test triggers (push/pull events) to help determine if the latest (`JDK 8`) had failed the from the **latest build** vs something in **your code** caused (or introduced). 

**For example**, when building with `JDK 8.0.192` (fixed version) the build/tests passes (Green) and JDK 8 fails (Red) will mean that the latest `JDK 8` was the cause and not your code. 

**Note:** Other distributions such as Temurin do not support archived fixed releases prior to Sept. 2021 and many non LTS (long term support) releases if you plan to try out newer features in the language.